### PR TITLE
fix #78 - Const usage may be broken in some cases.

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -13,6 +13,45 @@ namespace WPMailSMTP;
 class Options {
 
 	/**
+	 * @var array Map of all the default options of the plugin.
+	 */
+	private static $map = array(
+		'mail'     => array(
+			'from_name',
+			'from_email',
+			'mailer',
+			'return_path',
+		),
+		'smtp'     => array(
+			'host',
+			'port',
+			'encryption',
+			'auth',
+			'user',
+			'pass',
+		),
+		'gmail'    => array(
+			'client_id',
+			'client_secret',
+		),
+		'mailgun'  => array(
+			'api_key',
+			'domain',
+		),
+		'sendgrid' => array(
+			'api_key',
+		),
+		'pepipost' => array(
+			'host',
+			'port',
+			'encryption',
+			'auth',
+			'user',
+			'pass',
+		),
+	);
+
+	/**
 	 * That's where plugin options are saved in wp_options table.
 	 *
 	 * @var string
@@ -124,7 +163,7 @@ class Options {
 	/**
 	 * Get options by a group and a key.
 	 *
-	 * Options::init()->get('smtp', 'host') - will return only SMTP 'host' option.
+	 * Options::init()->get( 'smtp', 'host' ) - will return only SMTP 'host' option.
 	 *
 	 * @since 1.0.0
 	 *
@@ -180,6 +219,10 @@ class Options {
 
 			case 'auth':
 				$value = $group === 'smtp' && empty( $value ) ? false : true;
+				break;
+
+			case 'pass':
+				$value = $this->get_const_value( $group, $key, $value );
 				break;
 		}
 

--- a/src/Processor.php
+++ b/src/Processor.php
@@ -40,13 +40,13 @@ class Processor {
 	 */
 	public function phpmailer_init( $phpmailer ) {
 
-		$options = Options::init()->get_all();
-		$mailer  = $options['mail']['mailer'];
+		$options = new Options();
+		$mailer  = $options->get( 'mail', 'mailer' );
 
 		// Check that mailer is not blank, and if mailer=smtp, host is not blank.
 		if (
 			! $mailer ||
-			( 'smtp' === $mailer && ! $options['smtp']['host'] )
+			( 'smtp' === $mailer && ! $options->get( 'smtp', 'host' ) )
 		) {
 			return;
 		}
@@ -54,7 +54,7 @@ class Processor {
 		// If the mailer is pepipost, make sure we have a username and password.
 		if (
 			'pepipost' === $mailer &&
-			( ! $options['pepipost']['user'] && ! $options['pepipost']['pass'] )
+			( ! $options->get( 'pepipost', 'user' ) && ! $options->get( 'pepipost', 'pass' ) )
 		) {
 			return;
 		}
@@ -64,40 +64,38 @@ class Processor {
 		$phpmailer->Mailer = $mailer;
 
 		// Set the Sender (return-path) if required.
-		if ( isset( $options['mail']['return_path'] ) && $options['mail']['return_path'] ) {
+		if ( $options->get( 'mail', 'return_path' ) ) {
 			$phpmailer->Sender = $phpmailer->From;
 		}
 
 		// Set the SMTPSecure value, if set to none, leave this blank. Possible values: 'ssl', 'tls', ''.
-		if ( isset( $options[ $mailer ]['encryption'] ) ) {
-			if ( 'none' === $options[ $mailer ]['encryption'] ) {
-				$phpmailer->SMTPSecure = '';
-			} else {
-				$phpmailer->SMTPSecure = $options[ $mailer ]['encryption'];
-			}
+		if ( 'none' === $options->get( $mailer, 'encryption' ) ) {
+			$phpmailer->SMTPSecure = '';
+		} else {
+			$phpmailer->SMTPSecure = $options->get( $mailer, 'encryption' );
 		}
 
 		// If we're sending via SMTP, set the host.
 		if ( 'smtp' === $mailer ) {
 			// Set the other options.
-			$phpmailer->Host = $options[ $mailer ]['host'];
-			$phpmailer->Port = $options[ $mailer ]['port'];
+			$phpmailer->Host = $options->get( $mailer, 'host' );
+			$phpmailer->Port = $options->get( $mailer, 'port' );
 
 			// If we're using smtp auth, set the username & password.
-			if ( $options[ $mailer ]['auth'] ) {
+			if ( $options->get( $mailer, 'auth' ) ) {
 				$phpmailer->SMTPAuth = true;
-				$phpmailer->Username = $options[ $mailer ]['user'];
-				$phpmailer->Password = $options[ $mailer ]['pass'];
+				$phpmailer->Username = $options->get( $mailer, 'user' );
+				$phpmailer->Password = $options->get( $mailer, 'pass' );
 			}
 		} elseif ( 'pepipost' === $mailer ) {
 			// Set the Pepipost settings for BC.
 			$phpmailer->Mailer     = 'smtp';
 			$phpmailer->Host       = 'smtp.pepipost.com';
-			$phpmailer->Port       = $options[ $mailer ]['port'];
-			$phpmailer->SMTPSecure = $options[ $mailer ]['encryption'] === 'none' ? '' : $options[ $mailer ]['encryption'];
+			$phpmailer->Port       = $options->get( $mailer, 'port' );
+			$phpmailer->SMTPSecure = $options->get( $mailer, 'encryption' ) === 'none' ? '' : $options->get( $mailer, 'encryption' );
 			$phpmailer->SMTPAuth   = true;
-			$phpmailer->Username   = $options[ $mailer ]['user'];
-			$phpmailer->Password   = $options[ $mailer ]['pass'];
+			$phpmailer->Username   = $options->get( $mailer, 'user' );
+			$phpmailer->Password   = $options->get( $mailer, 'pass' );
 		}
 
 		// You can add your own options here.


### PR DESCRIPTION
`Options::$map` is not used, but left for future redesign of the class.

## Description

See #78 

## Testing procedure
1. Define the SMTP password in `wp-config`.
2. Save the settings in admin area
3. Try to send test email using SMTP mailer.
4. It should be fine.

## Types of changes
<!--- What types of changes does your code introduce? Put an x in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (modification of the currently available functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an x in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My code has appropriate phpdoc comments with description, @params, @since and @return.
- [x] My code is tested for both new installs and for users that are upgrading from older versions.
