### PR TITLE
fix #79 - Google API dependency is causing flags with security scanners.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,9 @@
       "/vendor/composer/installers/",
       "/vendor/firebase/",
       "/vendor/google/apiclient-services/src/Google/Service/",
+      "/vendor/phpseclib/phpseclib/phpseclib/File/",
+      "/vendor/phpseclib/phpseclib/phpseclib/Net/",
+      "/vendor/phpseclib/phpseclib/phpseclib/System/",
       "/src/"
     ]
   }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -62,7 +62,14 @@ var plugin = {
 		'!vendor/firebase',
 		// We need only a specific service: Gmail. Others should be omitted.
 		'!vendor/google/apiclient-services/src/Google/Service/!(Gmail)/**',
-		'!vendor/google/apiclient-services/src/Google/Service/!(Gmail|Gmail.php)'
+		'!vendor/google/apiclient-services/src/Google/Service/!(Gmail|Gmail.php)',
+		'!vendor/phpseclib/phpseclib/phpseclib/Crypt/!(AES.php|Rijndael.php|RSA.php|Random.php)',
+		'!vendor/phpseclib/phpseclib/phpseclib/Net/**',
+		'!vendor/phpseclib/phpseclib/phpseclib/Net',
+		'!vendor/phpseclib/phpseclib/phpseclib/File/**',
+		'!vendor/phpseclib/phpseclib/phpseclib/File',
+		'!vendor/phpseclib/phpseclib/phpseclib/System/**',
+		'!vendor/phpseclib/phpseclib/phpseclib/System'
 	],
 	php: [
 		'**/*.php',

--- a/src/Options.php
+++ b/src/Options.php
@@ -119,6 +119,7 @@ class Options {
 	 * @return array
 	 */
 	public function get_all() {
+
 		$options = $this->_options;
 
 		foreach ( $options as $group => $g_value ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Leaving in `phpseclib` only those files, that are really used.
That fixes some false-positives of files scanning plugins and decrease the zip size.

## Testing procedure

1. Gun `gulp process-zip` and install the resulting plugin zip.
2. Save client_id/secret for Gmail mailer.
3. Auth with Google to get token.
4. Refresh token (you can tweak its expiration in DB by decreasing the date for 2 hours; or wait for an hour).

## Types of changes
<!--- What types of changes does your code introduce? Put an x in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (modification of the currently available functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an x in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My code has appropriate phpdoc comments with description, @params, @since and @return.
- [x] My code is tested for both new installs and for users that are upgrading from older versions.
