### PR TITLE
fix #76 - Gmail: exception is thrown on WAMP on PHP 5.6 with bad local certificate.

### DIFF
--- a/src/Providers/Gmail/Auth.php
+++ b/src/Providers/Gmail/Auth.php
@@ -89,7 +89,11 @@ class Auth extends AuthAbstract {
 			empty( $this->gmail['access_token'] ) &&
 			! empty( $this->gmail['auth_code'] )
 		) {
-			$client->fetchAccessTokenWithAuthCode( $this->gmail['auth_code'] );
+			try {
+				$creds = $client->fetchAccessTokenWithAuthCode( $this->gmail['auth_code'] );
+			} catch ( \Exception $e ) {
+				$creds['error'] = $e->getMessage();
+			}
 
 			// Bail if we have an error.
 			if ( ! empty( $creds['error'] ) ) {
@@ -113,7 +117,18 @@ class Auth extends AuthAbstract {
 			}
 
 			if ( ! empty( $refresh ) ) {
-				$client->fetchAccessTokenWithRefreshToken( $refresh );
+				try {
+					$creds = $client->fetchAccessTokenWithRefreshToken( $refresh );
+				} catch ( \Exception $e ) {
+					$creds['error'] = $e->getMessage();
+				}
+
+				// Bail if we have an error.
+				if ( ! empty( $creds['error'] ) ) {
+					// TODO: save this error to display to a user later.
+					return $client;
+				}
+
 				$this->update_access_token( $client->getAccessToken() );
 				$this->update_refresh_token( $client->getRefreshToken() );
 			}


### PR DESCRIPTION
## Description

See #76.
On WAMP it seems there is some misconfiguration for PHP 5.6 and SSL support.
It throws an exception when trying to auth with Google to get access_token.

## Testing procedure

1. Install WAMP
2. Install WP site + WP Mail SMTP
3. Try to connect with Google
4. When `$client` is requested (after saving client_id/secret), a xDebug error message will appear, stopping the page load.

## Screenshots (if appropriate):

https://ppt.cc/fY16Bx@.png

## Types of changes
<!--- What types of changes does your code introduce? Put an x in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (modification of the currently available functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an x in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My code has appropriate phpdoc comments with a description, `@since`, `@params` and `@return`.
- [x] My code is tested for both new installs and for users that are upgrading from older versions.
