### PR TITLE
Workaround for Issue #149

### DIFF
--- a/src/Providers/Gmail/Auth.php
+++ b/src/Providers/Gmail/Auth.php
@@ -191,6 +191,11 @@ class Auth extends AuthAbstract {
 		if ( isset( $_GET['scope'] ) ) {
 			$scope = urldecode( $_GET['scope'] );
 		}
+		
+		if ($scope === 'workaround') {
+			// Workaround for mod_security's stupid rules
+			$scope = \Google_Service_Gmail::GMAIL_SEND;
+		}
 
 		// Let's try to get the access token.
 		if (


### PR DESCRIPTION
See #149.

mod_security will block any request if it contains an external URL as a parameter. Replace "scope=https://www.googleapis.com/auth/gmail.send" with "scope=workaround" in the blocked request.

This should only be temporary. Maybe we can get the people who make the rules for mod_security to whitelist googleapis.com