### PR TITLE
Change base_dir to return current plugin directory

### DIFF
--- a/wp-mail-smtp.php
+++ b/wp-mail-smtp.php
@@ -23,7 +23,7 @@ spl_autoload_register( function ( $class ) {
 	$plugin_folder = 'wp-mail-smtp';
 
 	// Default directory for all code is plugin's /src/.
-	$base_dir = WP_PLUGIN_DIR . '/' . $plugin_folder . '/src/';
+	$base_dir = plugin_dir_path(__DIR__) . '/' . $plugin_folder . '/src/';
 
 	// Get the relative class name.
 	$relative_class = substr( $class, strlen( $plugin_space ) + 1 );


### PR DESCRIPTION
This change is based on advice of this https://wordpress.stackexchange.com/a/192460/97235 answer and relates to issue #154

I hope this change may become useful to other users that want to have this as a must-use plugin and I appreciate the opportunity to contribute.

<!--- Provide a general summary of your changes in the Title above -->

## Description
This change aims to allow this plugin to be used as a `mu-plugin` on WordPress.

This is related to the issue #154 
<!--- Describe your changes in detail. -->
<!--- You can link a corresponding issue. -->

## Testing procedure
Before this change, I'd get a missing `Core` class load. After the change it has been loaded fine.

To keep file structure and given `mu-plugins` limitation, I've placed a symbolic link within the `wp-content/mu-plugins` pointing to the main plugin file within its folder.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an x in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (modification of the currently available functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an x in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My code has appropriate phpdoc comments with a description, `@since`, `@params` and `@return`.
- [ ] My code is tested for both new installs and for users that are upgrading from older versions.

***P.S.*** I've not checked the last two items because I am not sure if it applies on the first and if there is a through test that I'm not really aware of to follow in order to assure it.