### PR TITLE
issues-5 fix SendGrid error text/plain needs to be first

### DIFF
--- a/src/Providers/MailerAbstract.php
+++ b/src/Providers/MailerAbstract.php
@@ -107,8 +107,8 @@ abstract class MailerAbstract implements MailerInterface {
 		$this->set_subject( $this->phpmailer->Subject );
 		$this->set_content(
 			array(
-				'html' => $this->phpmailer->Body,
 				'text' => $this->phpmailer->AltBody,
+				'html' => $this->phpmailer->Body,
 			)
 		);
 		$this->set_return_path( $this->phpmailer->From );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
See issue: https://github.com/awesomemotive/WP-Mail-SMTP/issues/5

## Types of changes
<!--- What types of changes does your code introduce? Put an x in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (modification of the currently available functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an x in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My code has appropriate phpdoc comments with a description, `@since`, `@params` and `@return`.
- [x] My code is tested for both new installs and for users that are upgrading from older versions.
