### PR TITLE
use attachments[2] for attachment name for sending

### DIFF
--- a/src/Providers/Mailgun/Mailer.php
+++ b/src/Providers/Mailgun/Mailer.php
@@ -190,7 +190,7 @@ class Mailer extends MailerAbstract {
 
 			$data[] = array(
 				'content' => $file,
-				'name'    => $attachment[1],
+				'name'    => $attachment[2],
 			);
 		}
 


### PR DESCRIPTION
## Description
When adding an attachment, phpmailer source code sets the filepath to attachments[0], the filename (determined by basename(filepath)) to attachments[1], and an optional user specified name to attachments[2]. If the user does not specify a custom name, attachments[2] defers to the filename.

The Mailgun provider for this plugin should take the value at attachments[2] to use a possibly specified custom name that is defaulted to the basename.
https://github.com/PHPMailer/PHPMailer/blob/master/src/PHPMailer.php: lines 2785-2799

## Types of changes
- [x] Enhancement (modification of the currently available functionality)
