### PR TITLE
Add an option to bypass SSL authentication in GMail provider

### DIFF
--- a/src/Providers/Gmail/Auth.php
+++ b/src/Providers/Gmail/Auth.php
@@ -5,6 +5,7 @@ namespace WPMailSMTP\Providers\Gmail;
 use WPMailSMTP\Debug;
 use WPMailSMTP\Options as PluginOptions;
 use WPMailSMTP\Providers\AuthAbstract;
+use GuzzleHttp\Client;
 
 /**
  * Class Auth to request access and refresh tokens.
@@ -90,6 +91,13 @@ class Auth extends AuthAbstract {
 		// We request only the sending capability, as it's what we only need to do.
 		$client->setScopes( array( \Google_Service_Gmail::MAIL_GOOGLE_COM ) );
 		$client->setRedirectUri( self::get_plugin_auth_url() );
+		
+		if ($this->gmail['bypass_ssl']) {
+			$options = ['exceptions' => false,
+				    'verify' => false];
+			$httpClient = new Client($options);
+			$client->setHttpClient($httpClient);
+		}
 
 		if (
 			empty( $this->gmail['access_token'] ) &&

--- a/src/Providers/Gmail/Options.php
+++ b/src/Providers/Gmail/Options.php
@@ -111,6 +111,24 @@ class Options extends OptionsAbstract {
 			</div>
 		</div>
 
+		<!-- Bypass SSL validation -->
+		<div id="wp-mail-smtp-setting-row-<?php echo esc_attr( $this->get_slug() ); ?>-bypass_ssl" class="wp-mail-smtp-setting-row wp-mail-smtp-setting-row-text wp-mail-smtp-clear">
+			<div class="wp-mail-smtp-setting-label">
+				<label for="wp-mail-smtp-setting-<?php echo esc_attr( $this->get_slug() ); ?>-bypass_ssl"><?php esc_html_e( 'Bypass SSL Validation', 'wp-mail-smtp' ); ?></label>
+			</div>
+			<div class="wp-mail-smtp-setting-field">
+				<input type="checkbox" name="wp-mail-smtp[<?php echo esc_attr( $this->get_slug() ); ?>][bypass_ssl]"
+					value="true" <?php echo esc_attr( $this->options->get( $this->get_slug(), 'bypass_ssl' ) ) ? "checked=\"checked\"" : ""; ?>
+					id="wp-mail-smtp-setting-<?php echo esc_attr( $this->get_slug() ); ?>-bypass_ssl"
+				/>
+				<p class="desc">
+					<?php esc_html_e( 'Some hosting providers may have their certificate store misconfigured, causing emails to fail.', 'wp-mail-smtp' ); ?>
+					<br>
+					<?php esc_html_e( 'Select this option to bypass SSL verification.  (Do not use unless absolutely necessary!)', 'wp-mail-smtp' ); ?>
+				</p>
+			</div>
+		</div>
+
 		<!-- Auth users button -->
 		<div id="wp-mail-smtp-setting-row-<?php echo esc_attr( $this->get_slug() ); ?>-authorize"
 			class="wp-mail-smtp-setting-row wp-mail-smtp-setting-row-text wp-mail-smtp-clear">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
My hosting provider doesn't have its certificate chain correctly set up, so SSL validation fails when sending requests to GMail.

## Testing procedure
I have had this running on two production wordpress sites for a few months now, with no issues.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an x in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (modification of the currently available functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an x in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My code has appropriate phpdoc comments with a description, `@since`, `@params` and `@return`.
- [x] My code is tested for both new installs and for users that are upgrading from older versions.
