### PR TITLE
Other SMTP mailer: Use method that retrieves defined constant options.

### DIFF
--- a/src/Providers/SMTP/Mailer.php
+++ b/src/Providers/SMTP/Mailer.php
@@ -17,16 +17,10 @@ class Mailer extends MailerAbstract {
 	 */
 	public function is_mailer_complete() {
 
-		$options = $this->options->get_group( $this->mailer );
-
 		// Host and Port are the only really required options.
-		if (
-			! empty( $options['host'] ) &&
-			! empty( $options['port'] )
-		) {
-			return true;
-		}
+    $host = $this->options->get($this->mailer, 'host');
+    $port = $this->options->get($this->mailer, 'port');
+		return ( !empty( $host ) && !empty( $port ) );
 
-		return false;
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/awesomemotive/WP-Mail-SMTP/issues/27
