### PR TITLE
Options get_group() and get() return different values if using constants

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -170,7 +170,7 @@ class Options {
 	/**
 	 * Get all the options for a group.
 	 *
-	 * Options::init()->get_group('smtp') - will return the array of options, including defaults and constants.
+	 * Options::init()->get_group('smtp') - will return the array of options for the group, including defaults and constants.
 	 *
 	 * @since 1.0.0
 	 *
@@ -183,15 +183,15 @@ class Options {
 		// Just to feel safe.
 		$group = sanitize_key( $group );
 
-		if ( ! isset( $this->_options[ $group ] ) ) {
-			$this->_options[ $group ] = array();
+		$options = isset( $this->_options[ $group ] ) ? $this->_options[ $group ] : array();
+
+		if ( isset( self::$map[ $group ] ) ) {
+			foreach ( self::$map[ $group ] as $key ) {
+				$options[ $key ] = $this->get( $group, $key );
+			}
 		}
 
-		foreach ( isset( self::$map[ $group ] ) ? self::$map[ $group ] : array() as $key ) {
-			$this->_options[ $group ][ $key ] = $this->get( $group, $key );
-		}
-
-		return apply_filters( 'wp_mail_smtp_options_get_group', $this->_options[ $group ], $group );
+		return apply_filters( 'wp_mail_smtp_options_get_group', $options, $group );
 	}
 
 	/**

--- a/src/Options.php
+++ b/src/Options.php
@@ -170,29 +170,28 @@ class Options {
 	/**
 	 * Get all the options for a group.
 	 *
-	 * Options::init()->get_group('smtp') - will return only array of options (or empty array if a key doesn't exist).
+	 * Options::init()->get_group('smtp') - will return the array of options, including defaults and constants.
 	 *
 	 * @since 1.0.0
 	 *
 	 * @param string $group
 	 *
-	 * @return mixed
+	 * @return array
 	 */
 	public function get_group( $group ) {
 
 		// Just to feel safe.
 		$group = sanitize_key( $group );
 
-		if ( isset( $this->_options[ $group ] ) ) {
-
-			foreach ( $this->_options[ $group ] as $g_key => $g_value ) {
-				$options[ $group ][ $g_key ] = $this->get( $group, $g_key );
-			}
-
-			return apply_filters( 'wp_mail_smtp_options_get_group', $this->_options[ $group ], $group );
+		if ( ! isset( $this->_options[ $group ] ) ) {
+			$this->_options[ $group ] = array();
 		}
 
-		return array();
+		foreach ( isset( self::$map[ $group ] ) ? self::$map[ $group ] : array() as $key ) {
+			$this->_options[ $group ][ $key ] = $this->get( $group, $key );
+		}
+
+		return apply_filters( 'wp_mail_smtp_options_get_group', $this->_options[ $group ], $group );
 	}
 
 	/**

--- a/src/Providers/Sendgrid/Mailer.php
+++ b/src/Providers/Sendgrid/Mailer.php
@@ -334,10 +334,9 @@ class Mailer extends MailerAbstract {
 
 		$mg_text = array();
 
-		$options = new \WPMailSMTP\Options();
-		$mailgun = $options->get_group( 'sendgrid' );
+		$options = $this->options->get_group( $this->mailer );
 
-		$mg_text[] = '<strong>Api Key:</strong> ' . ( ! empty( $mailgun['api_key'] ) ? 'Yes' : 'No' );
+		$mg_text[] = '<strong>Api Key:</strong> ' . ( ! empty( $options['api_key'] ) ? 'Yes' : 'No' );
 
 		return implode( '<br>', $mg_text );
 	}


### PR DESCRIPTION
Reason for change was Options::init()->get( 'sendgrid', 'api_key' ) and Options::init()->get_group( 'sendgrid' )[ 'api_key' ] returned different values if you were using constants. 

So for our instant: 
Options::init()->get( 'sendgrid', 'api_key' ) would return the string.
Options::init()->get_group( 'sendgrid' )[ 'api_key' ] would return null and throw undefined index.

So Sendgrid\Mailer::is_mailer_complete would return false even though api_key was setup with constant, since it used the get_group method.

I updated get_group to return defaults and constants, where before it only returned database options. 

I also updated to always run apply_filters so developers can filter and return their own value when option is empty, because before filter only ran if group had database option. 

## Testing procedure
Tested saving admin.
Tested sending mail with external plugin.
Tested sending test mail with plugin.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
    -  \WPMailSMTP\Providers\Sendgrid\Mailer::is_mailer_complete now returns correctly when using constants.
- [x] Enhancement
   - \WPMailSMTP\Options::get_group now always runs wp_mail_smtp_options_get_group so developers can always filter and replace with their own values.
- [x] Breaking change (fix or feature that would cause existing functionality to change)
    - \WPMailSMTP\Options::get_group now returns defaults and constants


## Checklist:
Important notes on the breaking change, ideally should have no affects if developers are checking values. Only problem is if developers were checking the get_group array. Before would return empty array(), now always has some value.

Example:
```php
<?php
// Before with no option data set
$group_values = Options::init()->get_group('sendgrid') // array();

empty($group_values); // true;

empty($group_values['api_key']); // true;

isset($group_values['api_key']); // false;


// After with no option data set
$group_values = Options::init()->get_group('sendgrid') // array( 'api_key' => '' );

empty($group_values); // false;

empty($group_values['api_key']); // true;

isset($group_values['api_key']); // true;
```
 
Also another important note:
There was a local variable, $options, that was being set in foreach but not used anywhere. The get_all() method above passes $options into apply_filters(), but this method instead passes $this->_options[ $group ] into apply_fitlers(). I wanted to know if the goal of plugin was to always update and use $_options instead of local $options. Because either get_all() should be updated to match this style or get_group() should be updated to match get_all()'s style.
