### PR TITLE
instantiate MailCatcher with true so exceptions get thrown

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -554,7 +554,7 @@ class Core {
 	 */
 	protected function replace_w_fake_phpmailer( &$obj = null ) {
 
-		$obj = new MailCatcher();
+		$obj = new MailCatcher(true);
 
 		return $obj;
 	}

--- a/src/Core.php
+++ b/src/Core.php
@@ -554,7 +554,7 @@ class Core {
 	 */
 	protected function replace_w_fake_phpmailer( &$obj = null ) {
 
-		$obj = new MailCatcher(true);
+		$obj = new MailCatcher( true );
 
 		return $obj;
 	}


### PR DESCRIPTION
WordPress relies on the PHPMailer instance is instantiated with true to tell PHPMailer to throw exceptions. This way WordPress can catch those exceptions and fire the wp_mail_failed hook

Closes #44 