### PR TITLE
Fix for Notice of "Undefined offset"

### DIFF
--- a/src/Debug.php
+++ b/src/Debug.php
@@ -86,7 +86,7 @@ class Debug {
 		$all = self::get();
 
 		if ( ! empty( $all ) && is_array( $all ) ) {
-			return (string) $all[ count( $all ) - 1 ];
+			return (string) end($all);
 		}
 
 		return '';


### PR DESCRIPTION
The "Notice" appears if the "$all" array keys is out of order.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail. -->
<!--- You can link a corresponding issue. -->

## Testing procedure
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an x in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (modification of the currently available functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an x in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My code has appropriate phpdoc comments with a description, `@since`, `@params` and `@return`.
- [ ] My code is tested for both new installs and for users that are upgrading from older versions.
