### PR TITLE
Fixing #102. Embed string attachment directly.

### DIFF
--- a/src/Providers/Mailgun/Mailer.php
+++ b/src/Providers/Mailgun/Mailer.php
@@ -246,7 +246,10 @@ class Mailer extends MailerAbstract {
 			 * It is not always available, same as credentials for FTP.
 			 */
 			try {
-				if ( is_file( $attachment[0] ) && is_readable( $attachment[0] ) ) {
+				if ( $attachment[5] ) {
+					$file = $attachment[0];
+				}
+				else if ( is_file( $attachment[0] ) && is_readable( $attachment[0] ) ) {
 					$file = file_get_contents( $attachment[0] );
 				}
 			} catch ( \Exception $e ) {


### PR DESCRIPTION
## Description
This provides a fix for issue #102. String attachments will be recognized and not interpreted as file paths.


## Motivation and Context
Fixes #102.


## Types of changes
<!--- What types of changes does your code introduce? Put an x in all the boxes that apply. -->
<!--- Remove irrelevant points. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (modification of the currently available functionality)

## Checklist:
<!--- Go over all the following points, and put an x in all the boxes that apply. -->
<!--- Remove irrelevant points (when no docs changes needed at all, for example). -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've tested both Lite and Pro version of the plugin with these changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
