### PR TITLE
Add Live Preview blueprint

### DIFF
--- a/assets/wporg/blueprints/blueprint.json
+++ b/assets/wporg/blueprints/blueprint.json
@@ -1,0 +1,27 @@
+{
+  "landingPage": "/wp-admin/admin.php?page=wp-mail-smtp",
+  "steps": [
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "wp-mail-smtp"
+      },
+      "options": {
+        "activate": true
+      }
+    },
+    {
+      "step": "mkdir",
+      "path": "/wordpress/wp-content/mu-plugins"
+    },
+    {
+      "step": "writeFile",
+      "path": "/wordpress/wp-content/mu-plugins/addFilter-1.php",
+      "data": "<?php add_filter( 'wp_mail_smtp_admin_setup_wizard_load_wizard', '__return_false' );",
+      "progress": {
+        "caption": "addFilter: wp_mail_smtp_admin_setup_wizard_load_wizard"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Add Live Preview Blueprint for WordPress.org

Hi! I noticed that WP Mail SMTP doesn't have a Live Preview button on its WordPress.org page yet, so I created a blueprint configuration for it.

## About Live Preview

The [Live Preview feature](https://developer.wordpress.org/plugins/wordpress-org/previews-and-blueprints/) allows users to try plugins directly in their browser without installing anything, powered by [WordPress Playground](https://playground.wordpress.net/). This can significantly increase user engagement and conversions.

**Learn more:**
- [Plugin Handbook - Previews and Blueprints](https://developer.wordpress.org/plugins/wordpress-org/previews-and-blueprints/)
- [WordPress Playground Documentation](https://wordpress.github.io/wordpress-playground/)

## What's Included

This PR adds `assets/wporg/blueprints/blueprint.json` which configures the preview to:
- Install and activate WP Mail SMTP
- Log users in automatically
- Direct them to the WP Mail SMTP admin landing page

## Testing the Blueprint

You can test this blueprint right now in WordPress Playground (before merging):

**[▶️ Try it in Playground](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2FJanJakes%2FWP-Mail-SMTP%2Fpatch-1%2Fassets%2Fwporg%2Fblueprints%2Fblueprint.json)**

This lets you see exactly how users will experience the Live Preview!

## How to Enable

After merging this PR and syncing to your WordPress.org SVN repository at `/assets/blueprints/blueprint.json`:

1. Log in to your WordPress.org account
2. Go to [your plugin's Advanced page](https://wordpress.org/plugins/wp-mail-smtp/advanced/)
3. Scroll to **"Toggle Live Preview"**
4. Set the preview to **"public"**

The Live Preview button will then appear on your plugin page!

You can also test before enabling publicly by adding `?preview=1` to your plugin URL:
https://wordpress.org/plugins/wp-mail-smtp/?preview=1

## Customization

Feel free to customize the blueprint to better showcase your plugin's features. You can:
- Change the landing page
- Add demo content or sample data
- Configure specific PHP/WordPress versions
- Add setup steps

See the [Blueprint documentation](https://wordpress.github.io/wordpress-playground/blueprints-api/index) for all available options.

---

Let me know if you'd like any adjustments to better showcase WP Mail SMTP!